### PR TITLE
chore(docs): cleans up readme

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -53,13 +53,13 @@ This is based heavily upon the example of parcel with vue.js from the [parcel ex
 
 ## Related
 
-- [edm00se/create-vue-parcel][npm-init] an npm initializer (can be used to scaffold a copy of this starter with either `npm init` or `npx`)
+- [edm00se/create-vue-parcel][npm-init] an npm initializer
 
 ## Credits
 
-- [parcel-bundler/examples/Vue][parcel-examples-vue], upon which this is based.
-- [vue.js][vue]
 - [parcel][parcel]
+- [vue.js][vue]
+- [parcel-bundler/examples/Vue][parcel-examples-vue], upon which this is based
 
 ## License
 


### PR DESCRIPTION
Adding TypeScript support into a vue component with Parcel is insanely easy. Merely adding the attribute `lang="ts"` to the script block in `App.vue` prompts parcel to install typescript as a project dependency and update the dev server accordingly. 🔥⚡🎉