### PR TITLE
feat(ts): adds typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13287,6 +13287,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.6.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "prettier": "^1.18.2",
     "rimraf": "^3.0.0",
     "sass": "^1.23.3",
+    "typescript": "^3.7.2",
     "vue-hot-reload-api": "^2.3.4",
     "vue-jest": "^3.0.5",
     "vue-server-renderer": "^2.6.10",

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -7,7 +7,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 export default {
   name: 'app',
   data() {


### PR DESCRIPTION
Adding TypeScript support into a vue component with Parcel is insanely easy. Merely adding the attribute `lang="ts"` to the script block in `App.vue` prompts parcel to install typescript as a project dependency and update the dev server accordingly. 🔥⚡🎉